### PR TITLE
Updated gem

### DIFF
--- a/lib/mockserver/model/body.rb
+++ b/lib/mockserver/model/body.rb
@@ -22,11 +22,15 @@ module MockServer::Model
     include Hashie::Extensions::Coercion
 
     property :type, required: true
-    property :value
+    property :body
+    property :xpath
+    property :string
     property :parameters
 
     coerce_key :type, BodyType
-    coerce_key :value, String
+    coerce_key :body, String
+    coerce_key :xpath, String
+    coerce_key :string, String
     coerce_key :parameters, Parameters
   end
 
@@ -38,15 +42,15 @@ module MockServer::Model
     end
 
     def exact(value)
-      Body.new(type: :STRING, value: value)
+      Body.new(type: :STRING, string: value)
     end
 
     def regex(value)
-      Body.new(type: :REGEX, value: value)
+      Body.new(type: :REGEX, body: value)
     end
 
     def xpath(value)
-      Body.new(type: :XPATH, value: value)
+      Body.new(type: :XPATH, xpath: value)
     end
 
     def parameterized(*parameters)

--- a/lib/mockserver/model/request.rb
+++ b/lib/mockserver/model/request.rb
@@ -34,7 +34,7 @@ module MockServer::Model
     property :body, transform_with: (lambda do |body|
       if body && body.type.to_s == 'BINARY'
         body.type = :STRING
-        body.value = Base64.decode64(body.value)
+        body.string = Base64.decode64(body.string)
       end
 
       body
@@ -77,7 +77,7 @@ module MockServer::Model
       body = payload['body']
 
       if body && body.is_a?(String)
-        payload.merge!('body' => { 'type' => :STRING, 'value' => body })
+        payload.merge!('body' => { 'type' => :STRING, 'string' => body })
       end
 
       request = Request.new(symbolize_keys(payload))

--- a/lib/mockserver/model/times.rb
+++ b/lib/mockserver/model/times.rb
@@ -20,6 +20,10 @@ module MockServer::Model
     def initialize(supplied_value)
       @value = pre_process_value(supplied_value)
     end
+
+    def to_json(_opts={})
+      @value.to_s
+    end
   end
 
   # Model for times class

--- a/mockserver-client.gemspec
+++ b/mockserver-client.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description = 'A Ruby Client for MockServer that enables easy mocking of any system you integrate with via HTTP or HTTPS (i.e. services, web sites, etc)'
 
   spec.required_ruby_version     = '>= 2.0'
-  spec.required_rubygems_version = '~> 2.0'
+  spec.required_rubygems_version = '>= 2.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }

--- a/mockserver-client.gemspec
+++ b/mockserver-client.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json', '~> 1.8'
   spec.add_dependency 'json_pure', '~> 1.8'
   spec.add_dependency 'activesupport', '~> 4.1'
-  spec.add_dependency 'rest-client', '~> 1.7'
+  spec.add_dependency 'rest-client', '~> 2.0.2'
   spec.add_dependency 'logging_factory', '~> 0.0.2'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'colorize', '~> 0.7'

--- a/spec/fixtures/post_login_request.json
+++ b/spec/fixtures/post_login_request.json
@@ -16,7 +16,7 @@
         ],
         "body": {
             "type": "STRING",
-            "value": "{username:'foo', password:'bar'}"
+            "string": "{username:'foo', password:'bar'}"
         }
     }
 }

--- a/spec/fixtures/register_expectation.json
+++ b/spec/fixtures/register_expectation.json
@@ -45,6 +45,6 @@
     },
     "times": {
         "remainingTimes": 2,
-        "unlimited": "false"
+        "unlimited": false
     }
 }

--- a/spec/fixtures/register_expectation.json
+++ b/spec/fixtures/register_expectation.json
@@ -18,7 +18,7 @@
         ],
         "body": {
             "type": "STRING",
-            "value": "{\"username\":\"foo\",\"password\":\"bar\"}"
+            "string": "{\"username\":\"foo\",\"password\":\"bar\"}"
         }
     },
     "httpResponse": {

--- a/spec/fixtures/retrieved_request.json
+++ b/spec/fixtures/retrieved_request.json
@@ -17,6 +17,6 @@
   ],
   "body": {
     "type": "STRING",
-    "value": "{\"username\":\"foo\",\"password\":\"bar\"}"
+    "string": "{\"username\":\"foo\",\"password\":\"bar\"}"
   }
 }

--- a/spec/fixtures/times_once.json
+++ b/spec/fixtures/times_once.json
@@ -1,6 +1,6 @@
 {
   "times": {
     "remainingTimes": 1,
-    "unlimited": "false"
+    "unlimited": false
   }
 }

--- a/spec/mockserver/builder_spec.rb
+++ b/spec/mockserver/builder_spec.rb
@@ -83,8 +83,8 @@ describe MockServer::Model::DSL do
   end
 
   it 'generates times object correctly' do
-    expect(to_camelized_hash(unlimited)).to eq('unlimited' => 'true', 'remainingTimes' => 0)
-    expect(to_camelized_hash(at_least(2))).to eq('unlimited' => 'true', 'remainingTimes' => 2)
+    expect(to_camelized_hash(unlimited)).to eq('unlimited' => true, 'remainingTimes' => 0)
+    expect(to_camelized_hash(at_least(2))).to eq('unlimited' => true, 'remainingTimes' => 2)
   end
 
 

--- a/spec/mockserver/builder_spec.rb
+++ b/spec/mockserver/builder_spec.rb
@@ -77,8 +77,8 @@ describe MockServer::Model::DSL do
   end
 
   it 'generates body correctly' do
-    expect(to_camelized_hash(regex('*/login'))).to eq('type' => 'REGEX', 'value' => '*/login')
-    expect(to_camelized_hash(xpath('/login[1]'))).to eq('type' => 'XPATH', 'value' => '/login[1]')
+    expect(to_camelized_hash(regex('*/login'))).to eq('type' => 'REGEX', 'body' => '*/login')
+    expect(to_camelized_hash(xpath('/login[1]'))).to eq('type' => 'XPATH', 'xpath' => '/login[1]')
     expect(to_camelized_hash(parameterized(parameter('token', '4jy5hh')))).to eq('type' => 'PARAMETERS', 'parameters' => [{ 'name' => 'token', 'values' => ['4jy5hh'] }])
   end
 
@@ -92,21 +92,23 @@ describe MockServer::Model::DSL do
     let(:expectation) { MockServer::Model::Expectation.new }
     let(:request) { MockServer::Model::Request.new }
 
-    [{type: :XPATH, value: '/mock/instance'},
-     {type: :REGEX, value: '\d+.\d+'},
-     {type: :STRING, value: 'Mockserver is great'}].each do |request_hash|
+    [{type: :XPATH, xpath: '/mock/instance'},
+     {type: :REGEX, body: '\d+.\d+'},
+     {type: :STRING, string: 'Mockserver is great'}].each do |request_hash|
 
       it "generates a request body of type #{request_hash[:type]}" do
         request.body = MockServer::Model::Body.new(request_hash)
         expectation.request = request
 
+        result_hash = {}
+        request_hash.each do |key, value|
+          result_hash[key.to_s] = value.to_s
+        end
+
         expect(to_camelized_hash(expectation)).to eq({
           "httpRequest" => {
           "method" => "GET",
-            "body" => {
-              "type"  => request_hash[:type].to_s,
-              "value" => request_hash[:value].to_s
-            }
+            "body" => result_hash
           }
         })
       end
@@ -114,7 +116,7 @@ describe MockServer::Model::DSL do
 
     context 'when request body type binary' do
       let(:body) do
-        MockServer::Model::Body.new(type: :BINARY, value: 'TW9ja3NlcnZlciBpcyBncmVhdAo=')
+        MockServer::Model::Body.new(type: :BINARY, string: 'TW9ja3NlcnZlciBpcyBncmVhdAo=')
       end
 
       it 'correctly transforms to a string and updates the object' do
@@ -126,7 +128,7 @@ describe MockServer::Model::DSL do
             "method" => "GET",
             "body" => {
               "type" => "STRING",
-              "value" => "Mockserver is great\n"
+              "string" => "Mockserver is great\n"
             }
           }
         })

--- a/spec/mockserver/model/dsl_spec.rb
+++ b/spec/mockserver/model/dsl_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'MockServer::Model::DSL' do
 
       expect(request.headers).to eq headers
       expect(request.body.type.to_s).to eq 'STRING'
-      expect(request.body.value).to eq body_content
+      expect(request.body.string).to eq body_content
     end
   end
 end


### PR DESCRIPTION
Seems like this gem is pretty outdated, there were a lot of errors when communicating with the mockserver from Docker.

This PR fixes the most pressing bugs:
- body keys are converted from 'value' to 'string', 'xpath' or 'body'
- booleans are actual booleans, instead of strings