### PR TITLE
Updates deprecated API endpoints

### DIFF
--- a/lib/mockserver-client/api/control_api.rb
+++ b/lib/mockserver-client/api/control_api.rb
@@ -43,7 +43,7 @@ module MockServer
         fail ArgumentError, "Missing the required parameter 'ports' when calling ControlApi.bind_put"
       end
       # resource path
-      local_var_path = '/bind'
+      local_var_path = 'mockserver/bind'
 
       # query parameters
       query_params = {}
@@ -92,7 +92,7 @@ module MockServer
         @api_client.config.logger.debug 'Calling API: ControlApi.clear_put ...'
       end
       # resource path
-      local_var_path = '/clear'
+      local_var_path = 'mockserver/clear'
 
       # query parameters
       query_params = {}
@@ -136,7 +136,7 @@ module MockServer
         @api_client.config.logger.debug 'Calling API: ControlApi.reset_put ...'
       end
       # resource path
-      local_var_path = '/reset'
+      local_var_path = 'mockserver/reset'
 
       # query parameters
       query_params = {}
@@ -190,7 +190,7 @@ module MockServer
         fail ArgumentError, 'invalid value for "type", must be one of logs, requests, recorded_expectations, active_expectations'
       end
       # resource path
-      local_var_path = '/retrieve'
+      local_var_path = 'mockserver/retrieve'
 
       # query parameters
       query_params = {}
@@ -239,7 +239,7 @@ module MockServer
         @api_client.config.logger.debug 'Calling API: ControlApi.status_put ...'
       end
       # resource path
-      local_var_path = '/status'
+      local_var_path = 'mockserver/status'
 
       # query parameters
       query_params = {}
@@ -286,7 +286,7 @@ module MockServer
         @api_client.config.logger.debug 'Calling API: ControlApi.stop_put ...'
       end
       # resource path
-      local_var_path = '/stop'
+      local_var_path = 'mockserver/stop'
 
       # query parameters
       query_params = {}

--- a/lib/mockserver-client/api/expectation_api.rb
+++ b/lib/mockserver-client/api/expectation_api.rb
@@ -41,7 +41,7 @@ module MockServer
         fail ArgumentError, "Missing the required parameter 'expectations' when calling ExpectationApi.expectation_put"
       end
       # resource path
-      local_var_path = '/expectation'
+      local_var_path = '/mockserver/expectation'
 
       # query parameters
       query_params = {}

--- a/lib/mockserver-client/api/verify_api.rb
+++ b/lib/mockserver-client/api/verify_api.rb
@@ -41,7 +41,7 @@ module MockServer
         fail ArgumentError, "Missing the required parameter 'verification' when calling VerifyApi.verify_put"
       end
       # resource path
-      local_var_path = '/verify'
+      local_var_path = 'mockserver/verify'
 
       # query parameters
       query_params = {}
@@ -93,7 +93,7 @@ module MockServer
         fail ArgumentError, "Missing the required parameter 'verification_sequence' when calling VerifyApi.verify_sequence_put"
       end
       # resource path
-      local_var_path = '/verifySequence'
+      local_var_path = 'mockserver/verifySequence'
 
       # query parameters
       query_params = {}


### PR DESCRIPTION
The verify, control and expectations API endpoints in the latest version of this client are deprecated in the latest version of MockServer. This PR updates the endpoints, though perhaps a refreshed package generated by OpenAPI would be a more thorough solution.

**Example**:
```ruby
expectation_api.expectation_put(expectation_hash)
```
```
PUT /expectation HTTP/1.1
Host: localhost
Accept: */*
User-Agent: OpenAPI-Generator/5.3.0/ruby
Content-Type: application/json
Content-Length: 309
```
```
HTTP/1.1 201 Created
version: 5.8.1
deprecated: "/expectation" is deprecated use "/mockserver/expectation" instead
connection: keep-alive
content-length: 0
```